### PR TITLE
Do not use arrow functions because of IE11

### DIFF
--- a/lib/code_fund_web/templates/ad_serve/embed.js.eex
+++ b/lib/code_fund_web/templates/ad_serve/embed.js.eex
@@ -87,7 +87,7 @@ var _codefund = {
     var xobj = new XMLHttpRequest();
     xobj.overrideMimeType("application/json");
     xobj.open("GET", url, true);
-    xobj.onreadystatechange = () => {
+    xobj.onreadystatechange = function () {
       if (xobj.readyState === 4 && xobj.status === 200) {
         const json = JSON.parse(xobj.responseText);
         callback(json);


### PR DESCRIPTION
Recently I added the CodeFund plugin to https://sweetalert2.github.io/

Right now CodeFund plugin is broken for IE11 because of arrow function usage:

![image](https://user-images.githubusercontent.com/6059356/39395530-517b723a-4ae8-11e8-8bae-9d044b9a705a.png)

This PR will fix the issue and make IE11 users happy :)